### PR TITLE
Add Revise Lesson Plan button and correct state management

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -49,17 +49,24 @@ class App extends Component {
 
   // Update lesson information on current lesson
   setStateLesson = (id, title) => {
+    console.log("∞° In setStateLesson...");
+    console.log("∞° id=\n", id);
+    console.log("∞° title=\n", title);
     this.setState({
       lessonId: id,
       lessonTitle: title
     });
+    console.log("∞° this.state.lessonId=\n", this.state.lessonId);
+    console.log("∞° this.state.lessonTitle=\n", this.state.lessonTitle);
   };
 
   // Populate topics information for current lesson
   setStateTopics = (rawTopicsArray) => {
+    console.log("∞° In setStateTopics rawTopicsArray=\n", rawTopicsArray);
     const updateTopics = [];
     rawTopicsArray.forEach((topic, index) => {
       const idStr = topic.id.toString();
+      updateTopics[idStr] = {};
       updateTopics[idStr].id = topic.id;
       updateTopics[idStr].title = topic.title;
       updateTopics[idStr].duration = topic.duration;

--- a/client/src/components/lesson-card.js
+++ b/client/src/components/lesson-card.js
@@ -49,6 +49,18 @@ function LessonCard(props) {
     return true;
   };
 
+  const reviseLessonPlan = () => {
+    console.log("∞° reviseLessonPlan...");
+    // Pass up props to select this lesson before visiting /addtopic
+    const id=props.id
+    const title=props.title
+    console.log("∞° id=\n", id);
+    console.log("∞° title=\n", title);
+    props.setStateLesson(id, title)
+    history.push("/addtopic");
+    return true;
+  };
+
   const editLesson = () => {
     setViewOnly(false);
     return true;
@@ -101,15 +113,22 @@ function LessonCard(props) {
 
   const title = () => {
     const retVal = props.title || "Lesson";
-    console.log("∞° retVal=\n", retVal);
     return retVal;
   }
 
   const duration = () => {
-    const retVal = props.duration || "Amount of time";
-    console.log("∞° retVal=\n", retVal);
+    // Note, duration default to 0 so must explicitly check for bad iffy values
+    const retVal = typeof props.duration !== "undefined" && props.duration !== null
+      ? props.duration
+      : "Amount of time";
     return retVal;
   }
+
+      /* {{{ **
+      ** <p>props.id={props.id}</p>
+      ** <p>props.title={props.title}</p>
+      ** <p>props.duration={props.duration}</p>
+      ** }}} */
 
   return(
     <Card className="m-3">
@@ -139,6 +158,27 @@ function LessonCard(props) {
       </form>
       <Row>
         <Col>
+        {/* Edit button is hidden if id is null or otherwise invalid */}
+        {/* or if edit button functionality is not enabled         */}
+        {/* or if not currently in view mode anymore               */}
+        {props.id && props.canEdit && viewOnly
+          ? <Button variant="secondary" onClick={editLesson}>Edit</Button>
+          : ""
+        }
+        </Col>
+
+        <Col>
+        {/* Delete button is hidden if id is null or otherwise invalid */}
+        {/* or if delete button functionality is not enabled         */}
+        {props.id && props.canDelete
+          ? <Button variant="secondary" onClick={deleteLesson}>Delete</Button>
+          : ""
+        }
+        </Col>
+      </Row>
+
+      <Row>
+        <Col>
         {/* Start button is hidden if id is null or otherwise invalid */}
         {/* or if start button functionality is not enabled         */}
         {props.id && props.canStart
@@ -148,19 +188,10 @@ function LessonCard(props) {
         </Col>
 
         <Col>
-        {/* Edit button is hidden if id is null or otherwise invalid */}
+        {/* Revise button is hidden if id is null or otherwise invalid */}
         {/* or if edit button functionality is not enabled         */}
-        {/* or if not currently in view mode anymore               */}
-        {props.id && props.canEdit && viewOnly
-          ? <Button variant="secondary" onClick={editLesson}>Edit</Button>
-          : ""
-        }
-        </Col>
-        <Col>
-        {/* Delete button is hidden if id is null or otherwise invalid */}
-        {/* or if delete button functionality is not enabled         */}
-        {props.id && props.canDelete
-          ? <Button variant="secondary" onClick={deleteLesson}>Delete</Button>
+        {props.id && props.canRevise
+          ? <Button variant="secondary" onClick={reviseLessonPlan}>Revise Lesson Plan</Button>
           : ""
         }
         </Col>

--- a/client/src/components/prog-title.js
+++ b/client/src/components/prog-title.js
@@ -1,6 +1,5 @@
-import React, { useRef, useState } from "react";
-import { useHistory } from "react-router-dom";
-import { Col, Row, Jumbotron } from "react-bootstrap";
+import React from "react";
+import { Jumbotron } from "react-bootstrap";
 
     /* {{{ **
     ** <Row>

--- a/client/src/pages/add-topic.js
+++ b/client/src/pages/add-topic.js
@@ -62,6 +62,8 @@ class AddTopic extends React.Component {
   }
 
   loadTopicsOnLessonPlan = () => {
+    console.log("∞° loadTopicsOnLessonPlan...");
+    console.log("∞° this.props.lessonId=\n", this.props.lessonId);
     API.getAllTopicsByLessonId(this.props.lessonId)
       .then(res => {
         console.log("∞° res=\n", res);
@@ -71,6 +73,7 @@ class AddTopic extends React.Component {
         this.props.setStateLessonTime();
       })
       .catch(err => console.log(err));
+    console.log("∞° exiting loadTopicsOnLessonPlan...");
   };
 
   render() {

--- a/client/src/pages/homepage.js
+++ b/client/src/pages/homepage.js
@@ -59,6 +59,7 @@ class HomePage extends React.Component {
                     setStateLessonTime={this.props.setStateLessonTime}
                     viewOnly={true}
                     canStart={true}
+                    canRevise={true}
                     canEdit={true}
                     canDelete={true}
                     id={lessonPlan.id}

--- a/client/src/pages/live-lesson.js
+++ b/client/src/pages/live-lesson.js
@@ -51,6 +51,7 @@ class LiveLesson extends React.Component {
                 setStateLessonTime={this.props.setStateLessonTime}
                 viewOnly={true}
                 canStart={true}
+                canRevise={false}
                 canEdit={false}
                 canDelete={false}
                 id={this.props.lessonId}


### PR DESCRIPTION
It is now possible to go back and change a lesson plan after navigating off it.  The total duration still refuses to store.  Also, when a lesson is deleted on LessonCard the HomePage does not refresh correctly.