### PR TITLE
Add class status that changes background for current topic

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -28,3 +28,19 @@ body {
 ::placeholder {
   color: black;
 }
+
+.classAheadOfTime {
+  background-color: rgb(145,145,253);
+}
+
+.classOnTime {
+  background-color: rgb(90,252,112);
+}
+
+.classAtTime {
+  background-color: rgb(252,241,90);
+}
+
+.classOverTime {
+  background-color: rgb(251,75,75);
+}

--- a/client/src/components/time-status-card.js
+++ b/client/src/components/time-status-card.js
@@ -60,8 +60,11 @@ function TimeStatusCard(props) {
   ** }}} */
 
   function renderTime() {
-    setMinDisplay(getFormattedMinutes());
-    setSecDisplay(getFormattedSeconds());
+    const mins = getFormattedMinutes();
+    const secs = getFormattedSeconds();
+    setMinDisplay(mins);
+    setSecDisplay(secs);
+    props.setCurrStatus(mins,secs); // Pass back minutes elaspsed for styling
   }
 
   function startTimer() {

--- a/client/src/components/topic-card.js
+++ b/client/src/components/topic-card.js
@@ -152,6 +152,7 @@ function TopicCard(props) {
   const cardClassName = () => {
     return `m-3 ${props.classTime}`;
   }
+
   return (
     <Container className="d-flex justify-content-left align-items-left">
       <Card className={cardClassName()} style={{ width: "80vw" }}>

--- a/client/src/components/topic-card.js
+++ b/client/src/components/topic-card.js
@@ -149,9 +149,12 @@ function TopicCard(props) {
     return retVal;
   }
 
+  const cardClassName = () => {
+    return `m-3 ${props.classTime}`;
+  }
   return (
     <Container className="d-flex justify-content-left align-items-left">
-      <Card className="m-3" style={{ width: "80vw" }}>
+      <Card className={cardClassName()} style={{ width: "80vw" }}>
         <form className="form" onSubmit={handleSubmit}>
           <Row className="mb-2">
             <Col>

--- a/client/src/pages/add-topic.js
+++ b/client/src/pages/add-topic.js
@@ -55,6 +55,7 @@ class AddTopic extends React.Component {
                 title=""
                 duration={0}
                 notes=""
+                classTime="classNoStatus"
               />
               <h3>List of Topics</h3>
               {this.props.topicsArray.map((topic) => {
@@ -76,6 +77,7 @@ class AddTopic extends React.Component {
                     title={topic.title}
                     duration={topic.duration}
                     notes={topic.notes}
+                    classTime="classNoStatus"
                   />
                 );
               })}

--- a/client/src/pages/live-lesson.js
+++ b/client/src/pages/live-lesson.js
@@ -11,6 +11,9 @@ import TopicAPI from "../utils/databaseTopicAPI";
 class LiveLesson extends React.Component {
   state = {
     lessonId: null,
+    currStatus: "classNoStatus",
+    targetTimeBefore: 0,
+    targetTimeAfter: 0,
     currIndex: null,
     currTopic: null,
     nextIndex: null,
@@ -21,7 +24,38 @@ class LiveLesson extends React.Component {
     this.loadTopicsOnLessonPlan();
   }
 
-  setCurrentTargetTimes(topics, curr, next) {
+  setCurrStatusOnCurrentCard = (elapsedMinutes, elapsedSeconds) => {
+    const mins=parseInt(elapsedMinutes);
+    const secs=parseInt(elapsedSeconds);
+    if ((mins + secs) === 0) {
+      this.setState({
+        currStatus: "classNoStatus"
+      });
+    }
+    else if (mins < this.state.targetTimeBefore) {
+      this.setState({
+        currStatus: "classAheadOfTime"
+      });
+    }
+    else if ((mins === (this.state.targetTimeAfter - 1)) && (secs > 30)) {
+      this.setState({
+        currStatus: "classAtTime"
+      });
+    }
+    else if (mins >= this.state.targetTimeAfter) {
+      this.setState({
+        currStatus: "classOverTime"
+      });
+    }
+    else {
+      this.setState({
+        currStatus: "classOnTime"
+      });
+    }
+    return true;
+  }
+
+  setCurrentTargetTimes = (topics, curr, next) => {
     // Compute planned target times for the begining and ending of the
     // currently displayed topic, which can be compared to the actual
     // elapsed presentation time.
@@ -78,10 +112,6 @@ class LiveLesson extends React.Component {
       .catch(err => console.log(err));
   };
 
-  startTimer = () => {
-    return true;
-  };
-
   goToBackTopic = () => {
     console.log("∞° goToBackTopic...");
     // Scroll backward if possible to previous topic.
@@ -127,6 +157,9 @@ class LiveLesson extends React.Component {
 
   currTopicJSX = () => {
     if (this.state.currTopic) {
+      /* {{{ **
+      ** this.setCurrStatusOnCurrentCard(-1);
+      ** }}} */
       return (
         <>
           <Row>
@@ -144,6 +177,7 @@ class LiveLesson extends React.Component {
               title={this.state.currTopic.title}
               duration={this.state.currTopic.duration}
               notes={this.state.currTopic.notes}
+              classTime={this.state.currStatus}
             />
             </Col>
           </Row>
@@ -181,6 +215,7 @@ class LiveLesson extends React.Component {
           title={this.state.nextTopic.title}
           duration={this.state.nextTopic.duration}
           notes={this.state.nextTopic.notes}
+          classTime="classNoStatus"
         />
       );
     }
@@ -227,6 +262,7 @@ class LiveLesson extends React.Component {
                 caption="Topic time goals and actual time spent"
                 targetTimeBefore={this.state.targetTimeBefore}
                 targetTimeAfter={this.state.targetTimeAfter}
+                setCurrStatus={this.setCurrStatusOnCurrentCard}
               />
               <h3>Current topic</h3>
               {this.currTopicJSX()}


### PR DESCRIPTION
Code has been added so that LiveLesson can change the background color of the Card component in TopicCard, when the timer has been started.  

Only the Current Topic has its card affected, based on its topic start and topic ending times.

When 0 minutes and 0 seconds have elapsed the normal background is used.  When the elapsed time is greater than or equal to the topic start time, but less then the topic end time, the card's background is green until after 30 seconds to go, at which time the background changes to a goldenrod yellow color.  If the elapsed time is already after the topic end time, the background is red.  On the other hand, when scrolling ahead, if the elapsed time is before the topic start time, the background is blue color to indicate this card does not need to be started yet.